### PR TITLE
Migrate from SwipeRefresh to PullToRefreshBox for better Material 3 integration #955

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,7 +143,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtimeCompose)
     implementation(libs.androidx.lifecycle.viewModelCompose)
     implementation(libs.accompanist.appcompat.theme)
-    implementation(libs.accompanist.swiperefresh)
 
     debugImplementation(composeBom)
     debugImplementation(libs.androidx.compose.ui.tooling.core)

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ComposeUtils.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ComposeUtils.kt
@@ -16,11 +16,14 @@
 
 package com.example.android.architecture.blueprints.todoapp.util
 
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 
 val primaryDarkColor: Color = Color(0xFF263238)
 
@@ -34,6 +37,7 @@ val primaryDarkColor: Color = Color(0xFF263238)
  * @param modifier the modifier to apply to this layout.
  * @param content (slot) the main content to show
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LoadingContent(
     loading: Boolean,
@@ -45,12 +49,27 @@ fun LoadingContent(
 ) {
     if (empty) {
         emptyContent()
-    } else {
-        SwipeRefresh(
-            state = rememberSwipeRefreshState(loading),
-            onRefresh = onRefresh,
+    }  else {
+        // Initialize the PullToRefresh state using remember
+        val pullToRefreshState = rememberPullToRefreshState()
+
+        PullToRefreshBox(
+            isRefreshing = loading,  // use the loading directly for refreshing state
+            onRefresh = onRefresh,  // define the onRefresh event
+            state = pullToRefreshState,  // pass the remembered state
             modifier = modifier,
-            content = content,
-        )
+            contentAlignment = Alignment.TopStart,
+            indicator = {
+                // Define the indicator for pull-to-refresh
+                Indicator(
+                    modifier = Modifier.align(Alignment.TopCenter),
+                    isRefreshing = loading,
+                    state = pullToRefreshState
+                )
+            }
+        ) {
+            content()  // Main content
+        }
     }
+
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ kotlinxSerializationJson = "1.7.3"
 ksp = "2.1.0-1.0.29"
 lint = "31.7.3"
 # @keep
+materialZ = "1.8.0-alpha07"
 minSdk = "21"
 okhttp = "4.10.0"
 protobuf = "3.21.12"
@@ -61,7 +62,6 @@ turbine = "0.12.1"
 [libraries]
 accompanist-appcompat-theme = { group = "com.google.accompanist", name = "accompanist-appcompat-theme", version.ref = "accompanist" }
 accompanist-flowlayout = { group = "com.google.accompanist", name = "accompanist-flowlayout", version.ref = "accompanist" }
-accompanist-swiperefresh = { group = "com.google.accompanist", name = "accompanist-swiperefresh", version.ref = "accompanist" }
 accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "accompanist" }
 accompanist-testharness = { group = "com.google.accompanist", name = "accompanist-testharness", version.ref = "accompanist" }
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }


### PR DESCRIPTION
### Purpose:
This PR migrates the code from the Accompanist `SwipeRefresh` to Jetpack Compose’s Material 3 `PullToRefreshBox`. This is done to align the project with the latest standards provided by Material 3, improving compatibility and offering a more efficient solution for handling pull-to-refresh functionality.

### Changes:
- Replaced the `SwipeRefresh` component with `PullToRefreshBox` in the `LoadingContent` composable function.
- The pull-to-refresh functionality is now handled using Material 3's `PullToRefreshBox` state, providing better integration with the Compose framework.

### Impact:
- This migration simplifies state management using Material 3 components.
- Improved consistency with Jetpack Compose Material 3 practices.
- No functional changes — the behavior remains the same.

### Testing:
- All existing tests should pass without any changes. Please verify the behavior in a fresh pull-to-refresh scenario.
